### PR TITLE
PLATUI-301 Json reads for int-like strings

### DIFF
--- a/src/main/scala/uk/gov/hmrc/govukfrontend/views/IntString.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/views/IntString.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.govukfrontend.views
+
+import play.api.libs.json.{Format, JsError, JsNumber, JsResult, JsString, JsSuccess, JsValue, Reads}
+
+import scala.util.Try
+
+
+case class IntString(int: Int) extends AnyVal {
+  def str: String = int.toString
+}
+
+object IntString {
+
+  def apply(intStr: String): Try[IntString] = Try(intStr.toInt).map(IntString(_))
+
+  implicit object IntStringFormat extends Format[IntString] {
+    def reads(json: JsValue): JsResult[IntString] = json match {
+      case JsNumber(n) if n.isValidInt => JsSuccess(IntString(n.toInt))
+      case JsNumber(_) => JsError("error.expected.validinteger")
+      case JsString(s) => IntString(s).map(JsSuccess(_)).getOrElse(JsError("error.expected.integerstring"))
+      case _ => JsError("error.expected.integerjsstringorjsnumber")
+    }
+
+    def writes(o: IntString): JsString = JsString(o.str)
+  }
+
+  implicit class IntStringReads(intStringReads: Reads[IntString]) {
+    def int: Reads[Int] = intStringReads.map(_.int)
+    def str: Reads[String] = intStringReads.map(_.str)
+  }
+
+  implicit class IntStringNullableReads(intStringNullableReads: Reads[Option[IntString]]) {
+    def int: Reads[Option[Int]] = intStringNullableReads.map(_.map(_.int))
+    def str: Reads[Option[String]] = intStringNullableReads.map(_.map(_.str))
+  }
+
+}

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/charactercount/CharacterCount.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/charactercount/CharacterCount.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.govukfrontend.views.viewmodels.charactercount
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import uk.gov.hmrc.govukfrontend.views.IntString
 import uk.gov.hmrc.govukfrontend.views.viewmodels.CommonJsonFormats._
 import uk.gov.hmrc.govukfrontend.views.viewmodels.JsonDefaultValueFormatter
 import uk.gov.hmrc.govukfrontend.views.viewmodels.errormessage.ErrorMessage
@@ -47,11 +48,11 @@ object CharacterCount extends JsonDefaultValueFormatter[CharacterCount] {
     (
       (__ \ "id").read[String] and
         (__ \ "name").read[String] and
-        (__ \ "rows").read[Int] and
+        (__ \ "rows").read[IntString].int and
         (__ \ "value").readNullable[String] and
-        (__ \ "maxlength").readNullable[Int] and
-        (__ \ "maxwords").readNullable[Int] and
-        (__ \ "threshold").readNullable[Int] and
+        (__ \ "maxlength").readNullable[IntString].int and
+        (__ \ "maxwords").readNullable[IntString].int and
+        (__ \ "threshold").readNullable[IntString].int and
         (__ \ "label").read[Label] and
         (__ \ "hint").readNullable[Hint] and
         (__ \ "errorMessage").readNullable[ErrorMessage] and

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/panel/Panel.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/panel/Panel.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.govukfrontend.views.viewmodels.panel
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import uk.gov.hmrc.govukfrontend.views.IntString
 import uk.gov.hmrc.govukfrontend.views.viewmodels.JsonDefaultValueFormatter
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Content, Empty}
 
@@ -34,7 +35,7 @@ object Panel extends JsonDefaultValueFormatter[Panel] {
 
   override def defaultReads: Reads[Panel] =
     (
-      (__ \ "headingLevel").read[Int] and
+      (__ \ "headingLevel").read[IntString].int and
         (__ \ "classes").read[String] and
         (__ \ "attributes").read[Map[String, String]] and
         Content.readsHtmlOrText((__ \ "titleHtml"), (__ \ "titleText")) and

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/table/HeadCell.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/table/HeadCell.scala
@@ -19,6 +19,7 @@ package table
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import uk.gov.hmrc.govukfrontend.views.IntString
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Content, Empty}
 
 final case class HeadCell(
@@ -39,8 +40,8 @@ object HeadCell extends JsonDefaultValueFormatter[HeadCell] {
       Content.reads and
         (__ \ "format").readNullable[String] and
         (__ \ "classes").read[String] and
-        (__ \ "colspan").readNullable[Int] and
-        (__ \ "rowspan").readNullable[Int] and
+        (__ \ "colspan").readNullable[IntString].int and
+        (__ \ "rowspan").readNullable[IntString].int and
         (__ \ "attributes").read[Map[String, String]]
     )(HeadCell.apply _)
 

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/table/TableRow.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/table/TableRow.scala
@@ -19,6 +19,7 @@ package table
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import uk.gov.hmrc.govukfrontend.views.IntString
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Content, Empty}
 
 final case class TableRow(
@@ -39,8 +40,8 @@ object TableRow extends JsonDefaultValueFormatter[TableRow] {
       Content.reads and
         (__ \ "format").readNullable[String] and
         (__ \ "classes").read[String] and
-        (__ \ "colspan").readNullable[Int] and
-        (__ \ "rowspan").readNullable[Int] and
+        (__ \ "colspan").readNullable[IntString].int and
+        (__ \ "rowspan").readNullable[IntString].int and
         (__ \ "attributes").read[Map[String, String]]
     )(TableRow.apply _)
 

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/textarea/Textarea.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/textarea/Textarea.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.govukfrontend.views.viewmodels.textarea
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import uk.gov.hmrc.govukfrontend.views.html.components._
+import uk.gov.hmrc.govukfrontend.views.IntString
 import uk.gov.hmrc.govukfrontend.views.viewmodels.CommonJsonFormats._
 import uk.gov.hmrc.govukfrontend.views.viewmodels.JsonDefaultValueFormatter
 
@@ -45,7 +46,7 @@ object Textarea extends JsonDefaultValueFormatter[Textarea] {
     (
       (__ \ "id").read[String] and
         (__ \ "name").read[String] and
-        (__ \ "rows").read[Int] and
+        (__ \ "rows").read[IntString].int and
         (__ \ "value").readNullable[String] and
         (__ \ "describedBy").readNullable[String] and
         (__ \ "label").read[Label] and

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/views/IntStringSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/views/IntStringSpec.scala
@@ -160,11 +160,11 @@ class IntStringSpec extends WordSpec with Matchers with ScalaCheckDrivenProperty
         val expectedIntOption = Some(int)
 
         val optReadsStub = new Reads[Option[IntString]] {
-          def reads(jsValue: JsValue): JsResult[Option[IntString]] = JsSuccess(Some(IntString(expectedIntOption.get)))
+          def reads(jsValue: JsValue): JsResult[Option[IntString]] = JsSuccess(Some(jsValue.as[IntString]))
         }
 
         val intermediateReads: Reads[Option[Int]] = optReadsStub.int
-        JsString("foo").as[Option[Int]](intermediateReads) shouldBe expectedIntOption
+        JsString(s"$int").as[Option[Int]](intermediateReads) shouldBe expectedIntOption
       }
     }
 

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/views/IntStringSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/views/IntStringSpec.scala
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.govukfrontend.views
+
+import org.scalatest.{Matchers, WordSpec}
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json.{JsArray, JsBoolean, JsNull, JsNumber, JsResult, JsString, JsSuccess, JsValue, Json, Reads}
+
+import scala.util.Try
+
+
+class IntStringSpec extends WordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+
+  "fields for IntString" should {
+    "return int for int field" in {
+      forAll { int: Int =>
+        val intString = IntString(int)
+        intString.int shouldBe int
+      }
+    }
+
+    "return string form of int for str field" in {
+      forAll { int: Int =>
+        val intString = IntString(int)
+        intString.str shouldBe int.toString
+      }
+    }
+  }
+
+  "apply" should {
+    "apply directly on int parameter" in {
+      forAll { int: Int =>
+        IntString.apply(int)
+      }
+    }
+
+    "apply with success on int-like string" in {
+      forAll { int: Int =>
+        val validIntString: String = int.toString
+        IntString(validIntString).isSuccess
+      }
+    }
+
+    "apply with failure on non int-like string" in {
+      forAll {invalidIntString: String =>
+        whenever (Try(invalidIntString.toInt).isFailure) {
+          val attempt = IntString(invalidIntString)
+          assert(attempt.isFailure)
+          assert(attempt.failed.get.isInstanceOf[NumberFormatException])
+        }
+      }
+    }
+  }
+
+  "implicit reads" should {
+
+    "parse JsNumber with integer numbers as IntString" in {
+      forAll { int: Int =>
+        val jsNumber = JsNumber(int)
+        val intString = jsNumber.as[IntString]
+        intString.int shouldBe int
+      }
+    }
+
+    "fail to parse JsNumber with non-integer numbers as IntString" in {
+      forAll { bigDecimal: BigDecimal =>
+        whenever (!bigDecimal.isValidInt) {
+          val jsNumber = JsNumber(bigDecimal)
+          val attempt = Try(jsNumber.as[IntString])
+          assert(attempt.isFailure)
+          attempt.failed.map(_.getMessage).get should include("error.expected.validinteger")
+        }
+      }
+    }
+
+    "parse integer-like JsString as IntString" in {
+      forAll { int: Int =>
+        val validIntString: String = int.toString
+        val jsString = JsString(validIntString)
+        val intString = jsString.as[IntString]
+        intString.int shouldBe int
+        intString.str shouldBe validIntString
+      }
+    }
+
+    "fail to parse JsString with non integer-like numbers as IntString" in {
+      forAll { invalidIntString: String =>
+        whenever (Try(invalidIntString.toInt).isFailure) {
+          val jsString = JsString(invalidIntString)
+          val attempt = Try(jsString.as[IntString])
+          assert(attempt.isFailure)
+          attempt.failed.map(_.getMessage).get should include("error.expected.integerstring")
+        }
+      }
+    }
+
+    "fail to parse JsValues that are neither JsNumbers nor JsStrings to IntString" in {
+      val invalidJsValues: Iterable[JsValue] = Iterable(JsArray(), JsBoolean(false), JsBoolean(true), JsNull, Json.obj("foo" -> "bar"))
+
+      invalidJsValues.foreach { jsValue =>
+        val attempt = Try(jsValue.as[IntString])
+        assert(attempt.isFailure, s"- JsValue [${jsValue.getClass}: $jsValue] was unexpectedly able to be parsed as IntString instead of failing.")
+        withClue(s"- JsValue [${jsValue.getClass}: $jsValue] had incorrect error"){
+          attempt.failed.map(_.getMessage).get should include("error.expected.integerjsstringorjsnumber")
+        }
+      }
+    }
+  }
+
+  "explicit reads" should {
+
+    "give means to map JsValues that can successfully be parsed as IntString to Int" in {
+      val reads: Reads[IntString] = implicitly[Reads[IntString]]
+      val intermediateReads: Reads[Int] = reads.int
+      forAll { int: Int =>
+
+        val jsInt = JsNumber(int)
+        val parsedInt = jsInt.as[Int](intermediateReads)
+        int shouldBe parsedInt
+
+        val validIntString: String = int.toString
+        val jsString = JsString(validIntString)
+        val intParsedFromString = jsString.as[Int](intermediateReads)
+        int shouldBe intParsedFromString
+      }
+    }
+
+    "give means to map JsValues that can successfully be parsed as IntString to String" in {
+      val reads: Reads[IntString] = implicitly[Reads[IntString]]
+      val intermediateReads: Reads[String] = reads.str
+      forAll { int: Int =>
+
+        val jsInt = JsNumber(int)
+        val strParsedFromInt = jsInt.as[String](intermediateReads)
+        int.toString shouldBe strParsedFromInt
+
+        val validIntString: String = int.toString
+        val jsString = JsString(validIntString)
+        val strParsedFromIntString = jsString.as[String](intermediateReads)
+        validIntString shouldBe strParsedFromIntString
+      }
+    }
+
+    "give means to map JsValues that can successfully be parsed as Some[IntString] to Some[Int]" in {
+      forAll { int: Int =>
+        val expectedIntOption = Some(int)
+
+        val optReadsStub = new Reads[Option[IntString]] {
+          def reads(jsValue: JsValue): JsResult[Option[IntString]] = JsSuccess(Some(IntString(expectedIntOption.get)))
+        }
+
+        val intermediateReads: Reads[Option[Int]] = optReadsStub.int
+        JsString("foo").as[Option[Int]](intermediateReads) shouldBe expectedIntOption
+      }
+    }
+
+    "give means to map JsValues that can successfully be parsed as None[IntString] to None[Int]" in {
+      val optReadsStub = new Reads[Option[IntString]] {
+        def reads(jsValue: JsValue): JsResult[Option[IntString]] = JsSuccess(None)
+      }
+
+      val intermediateReads: Reads[Option[Int]] = optReadsStub.int
+      JsString("foo").as[Option[Int]](intermediateReads) shouldBe None
+    }
+
+    "give means to map JsValues that can successfully be parsed as Some[IntString] to Some[String]" in {
+      forAll { int: Int =>
+        val expectedStrOption = Some(int.toString)
+
+        val optReadsStub = new Reads[Option[IntString]] {
+          def reads(jsValue: JsValue): JsResult[Option[IntString]] = JsSuccess(Some(IntString(int)))
+        }
+
+        val intermediateReads: Reads[Option[String]] = optReadsStub.str
+        JsString("foo").as[Option[String]](intermediateReads) shouldBe expectedStrOption
+      }
+    }
+
+    "give means to map JsValues that can successfully be parsed as None[IntString] to None[String]" in {
+      val optReadsStub = new Reads[Option[IntString]] {
+        def reads(jsValue: JsValue): JsResult[Option[IntString]] = JsSuccess(None)
+      }
+
+      val intermediateReads: Reads[Option[String]] = optReadsStub.str
+      JsString("foo").as[Option[String]](intermediateReads) shouldBe None
+    }
+  }
+
+  "writes" should {
+    "output IntString as JsString" in {
+      forAll { int: Int =>
+        val intString = IntString(int)
+        Json.toJson(intString) shouldBe JsString(int.toString)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
For JSON objects that have fields that are
integers that are typed as strings, e.g.
"1", we should parse as an 'IntString'
rather than failing to read this as a
JsNumber. Equally, numbers such as 1
can also be parsed as an 'IntString'.

Hence, both an appropriate integer
JsNumber or JsString can be parsed;
else the field will fail to be
parsed with an appropriate JsError.

Parsing as an 'IntString' allows
the error to be attached to the
relevant field inside the JsError
rather than an error related to
mapping inappropriate strings to
ints after deserialisation, which
gives a more confusing stack trace.

This functionality allows us to
parse JsObject fields for components
in the same way GovUK frontend Nunjucks
does, not minding about whether an
integer-like field is a string or
integer initially.