### PR TITLE
PLATUI-436: support URL fragments in action attribute

### DIFF
--- a/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/helpers/formWithCSRF.scala.html
+++ b/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/helpers/formWithCSRF.scala.html
@@ -21,7 +21,9 @@
 @(action: play.api.mvc.Call,
   args: (Symbol,String)*
 )(body: => Html)(implicit request: RequestHeader, messages: Messages)
-<form action="@action.url" method="@action.method" @toHtmlArgs(args.toMap)>
-  @CSRF.formField
+<form action="@action.path" method="@action.method" @toHtmlArgs(args.toMap)>
+  @if(play.filters.csrf.CSRF.getToken.isDefined) {
+    @CSRF.formField
+  }
   @body
 </form>


### PR DESCRIPTION
Fix issue that causes an exception to be thrown when viewing a form if the CSRF token is missing from the request for any reason. This also makes the behaviour consistent with play-ui.