### PR TITLE
PLATUI-452: fix issue with double encoding of data attributes

### DIFF
--- a/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/components/govukCharacterCount.scala.html
+++ b/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/components/govukCharacterCount.scala.html
@@ -21,6 +21,13 @@
 @import params._
 @require(name.nonEmpty && id.nonEmpty, "name and id should be non-empty")
 @require(maxLength.isDefined || maxWords.isDefined, "maxLength or maxWords should be provided")
+
+@attrs = {
+  @maxLength.filter(_ > 0).map {value => data-maxlength="@value"}
+  @threshold.filter(_ > 0).map {value => data-threshold="@value"}
+  @maxWords.filter(_ > 0).map {value => data-maxwords="@value"}
+}
+
 <div class="govuk-character-count" data-module="govuk-character-count"@attrs>
   @govukTextarea(Textarea(
     id = id,
@@ -42,9 +49,3 @@
     content = Text("You can enter up to " + maxLength.filter(_ > 0).orElse(maxWords).getOrElse("undefined") + " " + maxWords.filter(_ > 0).fold("characters")(_ => "words"))
   ))
 </div>
-
-@attrs = {
-  @maxLength.filter(_ > 0).fold("")(max => s"""data-maxlength="${max}"""")
-  @threshold.filter(_ > 0).fold("")(max => s"""data-threshold="${max}"""")
-  @maxWords.filter(_ > 0).fold("")(max => s"""data-maxwords="${max}"""")
-}

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/views/CharacterReferenceUtils.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/views/CharacterReferenceUtils.scala
@@ -15,21 +15,20 @@
  */
 
 package uk.gov.hmrc.govukfrontend.views
-package components
 
-import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.govukfrontend.views.viewmodels.charactercount.CharacterCount
-import uk.gov.hmrc.govukfrontend.views.html.components._
-import scala.util.Try
+object CharacterReferenceUtils {
+  private val hexReferenceRegex = "&#x([0-9A-F]+);".r
 
-class govukCharacterCountSpec extends TemplateUnitSpec[CharacterCount]("govukCharacterCount") {
+  private def decimalReference(value: Int) = s"&#$value;"
+
+  private def hexToInt(value: String) = Integer.parseInt(value, 16)
+
   /**
-    * Calls the Twirl template with the given parameters and returns the resulting markup
+    * Converts a string containing hex character references to decimal character references
     *
-    * @param params
-    * @return [[Try[HtmlFormat.Appendable]]] containing the markup
+    * @param value
+    * @return
     */
-  override def render(params: CharacterCount): Try[HtmlFormat.Appendable] = {
-    Try(GovukCharacterCount(params))
-  }
+  def toDecimal(value: String): String =
+    hexReferenceRegex.replaceAllIn(value, matchValue => decimalReference(hexToInt(matchValue.group(1))))
 }

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/views/CharacterReferenceUtilsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/views/CharacterReferenceUtilsSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.govukfrontend.views
+
+import org.scalatest.{Matchers, WordSpec}
+import CharacterReferenceUtils.toDecimal
+
+class CharacterReferenceUtilsSpec extends WordSpec with Matchers {
+
+  "toDecimal" should {
+    "handle empty strings" in {
+      val original = ""
+
+      toDecimal(original) shouldBe original
+    }
+
+    "leave string unchanged if it does not contain a hex character reference" in {
+      val original = "this is a normal string &#123; with a decimal character reference"
+
+      toDecimal(original) shouldBe original
+    }
+
+    "convert a hex character reference to a decimal one" in {
+      val original = "&#x27;"
+      val expected = "&#39;"
+
+      toDecimal(original) shouldBe expected
+    }
+
+    "convert multiple character references" in {
+      val original = "reference one: &#x27;, and another reference &#xAE;"
+      val expected = "reference one: &#39;, and another reference &#174;"
+
+      toDecimal(original) shouldBe expected
+    }
+
+    "ignore malformed character references" in {
+      val original = "malformed &#; one"
+
+      toDecimal(original) shouldBe original
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/views/PreProcessor.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/views/PreProcessor.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.govukfrontend.views
 
 import com.googlecode.htmlcompressor.compressor.HtmlCompressor
 import com.googlecode.htmlcompressor.compressor.HtmlCompressor._
-import org.jsoup.parser.Parser
+import CharacterReferenceUtils._
 
 trait PreProcessor {
 
@@ -32,7 +32,7 @@ trait PreProcessor {
     */
   def parseAndCompressHtml(html: String): String = {
     compressor.setRemoveSurroundingSpaces(ALL_TAGS)
-    compressor.compress(Parser.unescapeEntities(html, false))
+    compressor.compress(toDecimal(html))
   }
 
   /***


### PR DESCRIPTION
Remove unescaping of references in unit tests - convert to decimal instead