### PR TITLE
govukLayout doesn't need implicit request: Request[_] parameter

### DIFF
--- a/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/layouts/govukLayout.scala.html
+++ b/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/layouts/govukLayout.scala.html
@@ -32,7 +32,7 @@
   footerItems: Seq[FooterItem] = Seq.empty,
   bodyEndBlock: Option[Html] = None,
   scriptsBlock: Option[Html] = None
-)(contentBlock: Html)(implicit request: Request[_], messages: Messages)
+)(contentBlock: Html)(implicit messages: Messages)
 
 @headerDefault = {
   @headerBlock.getOrElse {
@@ -73,4 +73,3 @@
   mainClasses = Some("govuk-main-wrapper--auto-spacing"),
   bodyEndBlock = Some(bodyEndDefault)
 )(mainContentDefault)
-


### PR DESCRIPTION
This prevents govukLayout from using in error handlers where there is
only RequestHeader available.

closes #53