### PR TITLE
PLATUI-486: Updated govuk default link.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.49.0] - 2020-07-03
+
+### Added
+
+- Set the default GOVUK link to the main GOVUK homepage
+
 ## [0.48.0] - 2020-06-19
 
 ### Added

--- a/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/layouts/govukLayout.scala.html
+++ b/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/layouts/govukLayout.scala.html
@@ -37,10 +37,10 @@
 @headerDefault = {
   @headerBlock.getOrElse {
     @govukHeader(Header(
-      homepageUrl = Some(messages("service.homePageUrl")),
+      homepageUrl = Some("https://www.gov.uk/"),
       serviceName = Some(messages("service.name")),
       serviceUrl = Some(messages("service.homePageUrl")),
-      containerClasses = Some("govuk-width-container")))
+      containerClasses = None))
   }
 }
 

--- a/src/test/resources/fixtures/additional-fixtures/layout-default/output.txt
+++ b/src/test/resources/fixtures/additional-fixtures/layout-default/output.txt
@@ -29,7 +29,7 @@
         <header class="govuk-header " role="banner" data-module="govuk-header">
             <div class="govuk-header__container govuk-width-container">
                 <div class="govuk-header__logo">
-                    <a href="service.homePageUrl" class="govuk-header__link govuk-header__link--homepage">
+                    <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
                         <span class="govuk-header__logotype">
                             <svg
                                     aria-hidden="true"


### PR DESCRIPTION
I've updated the URL, I've also removed the duplication of the class `govuk-width-container` - it was a default at more than one level which is usually a pretty bad idea.