### PR TITLE
BAU - fix for SummaryList with mixed actions

### DIFF
--- a/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/components/govukSummaryList.scala.html
+++ b/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/components/govukSummaryList.scala.html
@@ -46,7 +46,7 @@
       } else {
         @if(anyRowHasActions) {
           @* Add dummy column to extend border *@
-          <span class="govuk-summary-list__actions"></span>
+          <dd class="govuk-summary-list__actions"></dd>
         }
       }
     </div>

--- a/src/test/resources/fixtures/test-fixtures/summary-list-with-some-actions/output.txt
+++ b/src/test/resources/fixtures/test-fixtures/summary-list-with-some-actions/output.txt
@@ -30,7 +30,7 @@
           13/08/1980
         </dd>
           
-          <span class="govuk-summary-list__actions"></span>
+          <dd class="govuk-summary-list__actions"></dd>
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
@@ -49,6 +49,6 @@
         </p>
         </dd>
           
-          <span class="govuk-summary-list__actions"></span>
+          <dd class="govuk-summary-list__actions"></dd>
       </div>
 </dl>


### PR DESCRIPTION
This PR fixes an issue we have seen when creating a SummaryList with only some rows containing actions.
The "dummy" <span> element is not a valid child of a <dl>.   Changing the <span> to a <dd> solves the issue (warning  when using Axe tool goes away).