### PR TITLE
Adding `novalidate` attribute to form tags

### DIFF
--- a/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/helpers/formWithCSRF.scala.html
+++ b/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/helpers/formWithCSRF.scala.html
@@ -21,7 +21,7 @@
 @(action: play.api.mvc.Call,
   args: (Symbol,String)*
 )(body: => Html)(implicit request: RequestHeader, messages: Messages)
-<form action="@action.path" method="@action.method" @toHtmlArgs(args.toMap)>
+<form action="@action.path" method="@action.method" novalidate @toHtmlArgs(args.toMap)>
   @if(play.filters.csrf.CSRF.getToken.isDefined) {
     @CSRF.formField
   }

--- a/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/helpers/formWithCSRF.scala.html
+++ b/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/helpers/formWithCSRF.scala.html
@@ -21,7 +21,7 @@
 @(action: play.api.mvc.Call,
   args: (Symbol,String)*
 )(body: => Html)(implicit request: RequestHeader, messages: Messages)
-<form action="@action.path" method="@action.method" novalidate @toHtmlArgs(args.toMap)>
+<form action="@action.path" method="@action.method" @toHtmlArgs(args.toMap + ('novalidate -> None))>
   @if(play.filters.csrf.CSRF.getToken.isDefined) {
     @CSRF.formField
   }

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/views/helpers/formWithCSRFSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/views/helpers/formWithCSRFSpec.scala
@@ -53,6 +53,16 @@ class formWithCSRFSpec extends WordSpec with Matchers with JsoupHelpers with Mes
       form.attr("method") shouldBe "GET"
     }
 
+    "render with the novalidate attribute" in {
+      val getCall = Call(method = "GET", url = "/the-post-url")
+
+      val form =
+        FormWithCSRF.apply(action = getCall)(HtmlFormat.empty)
+          .select("form")
+
+      form.hasAttr("novalidate") shouldBe true
+    }
+
     "render the passed attributes" in {
       val form =
         FormWithCSRF.apply(action = postAction, 'attribute1 -> "value1")(HtmlFormat.empty)

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/views/helpers/formWithCSRFSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/views/helpers/formWithCSRFSpec.scala
@@ -63,6 +63,12 @@ class formWithCSRFSpec extends WordSpec with Matchers with JsoupHelpers with Mes
       form.hasAttr("novalidate") shouldBe true
     }
 
+    "not render duplicate novalidate attributes" in {
+      val form =
+        FormWithCSRF.apply(action = postAction, 'novalidate -> "novalidate")(HtmlFormat.empty)
+
+      form.toString should include("<form action=\"/the-post-url\" method=\"POST\" novalidate>")
+    }
     "render the passed attributes" in {
       val form =
         FormWithCSRF.apply(action = postAction, 'attribute1 -> "value1")(HtmlFormat.empty)


### PR DESCRIPTION
The GOV.UK design system specifies that HTML5 validation should be turned off by adding [novalidate](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-novalidate) to the form tags https://design-system.service.gov.uk/patterns/validation/
